### PR TITLE
Handle offline cache with relative paths

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -3,12 +3,20 @@ self.addEventListener('install', e => {
   e.waitUntil(
     caches.open('pnr-cache').then(cache => {
       return cache.addAll([
-        'https://pnrtaxi.com/resataxi/',
-        'https://pnrtaxi.com/resataxi/index.html',
-        'https://pnrtaxi.com/resataxi/manifest.json',
-        'https://pnrtaxi.com/resataxi/icon-192.png',
-        'https://pnrtaxi.com/resataxi/icon-512.png'
+        './',
+        './index.html',
+        './manifest.json',
+        './icon-192.png',
+        './icon-512.png'
       ]);
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
     })
   );
 });


### PR DESCRIPTION
## Summary
- reference cached resources with relative paths in the service worker
- add a fetch listener so cached files work offline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684453ec761c8331b46873b44dda8e52