### PR TITLE
Fix PWA manifest paths

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,18 @@
 {
   "name": "PNR Réservation Taxi",
   "short_name": "PNR Taxi",
-  "start_url": "https://pnrtaxi.com/resataxi/index.html",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#3b82f6",
   "icons": [
     {
-      "src": "https://pnrtaxi.com/resataxi/icon-192.png",
+      "src": "icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://pnrtaxi.com/resataxi/icon-512.png",
+      "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,11 +3,11 @@ self.addEventListener('install', e => {
   e.waitUntil(
     caches.open('pnr-cache').then(cache => {
       return cache.addAll([
-        'https://pnrtaxi.com/resataxi/',
-        'https://pnrtaxi.com/resataxi/index.html',
-        'https://pnrtaxi.com/resataxi/manifest.json',
-        'https://pnrtaxi.com/resataxi/icon-192.png',
-        'https://pnrtaxi.com/resataxi/icon-512.png'
+        './',
+        'index.html',
+        'manifest.json',
+        'icon-192.png',
+        'icon-512.png'
       ]);
     })
   );


### PR DESCRIPTION
## Summary
- use relative paths in `manifest.json`
- cache relative assets in service worker

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/manifest.json`
- `curl -I http://localhost:8000/icon-192.png`
- `curl -I http://localhost:8000/icon-512.png`


------
https://chatgpt.com/codex/tasks/task_e_684453ee83fc8331964b12432c62daa2